### PR TITLE
Dynamic dangling check on created variables

### DIFF
--- a/packages/reactive/src/effect.rs
+++ b/packages/reactive/src/effect.rs
@@ -3,7 +3,10 @@ use crate::{
     shared::{EffectRef, Shared, SignalContextRef},
 };
 use ahash::AHashSet;
-use std::{cell::RefCell, fmt};
+use std::{
+    cell::{Ref, RefCell},
+    fmt,
+};
 
 pub type Effect<'a> = &'a OwnedEffect<'a>;
 
@@ -16,13 +19,23 @@ impl fmt::Debug for OwnedEffect<'_> {
 /// An effect can track signals and automatically execute whenever the captured
 /// signals changed.
 pub struct OwnedEffect<'a> {
+    inner: Ref<'a, RawEffect<'a>>,
+}
+
+impl<'a> OwnedEffect<'a> {
+    pub fn run(&self) {
+        self.inner.run();
+    }
+}
+
+pub(crate) struct RawEffect<'a> {
     this: EffectRef,
     shared: &'static Shared,
     effect: &'a (dyn 'a + AnyEffect),
     dependencies: RefCell<AHashSet<SignalContextRef>>,
 }
 
-impl<'a> OwnedEffect<'a> {
+impl<'a> RawEffect<'a> {
     pub(crate) fn add_dependency(&self, signal: SignalContextRef) {
         self.dependencies.borrow_mut().insert(signal);
     }
@@ -30,7 +43,7 @@ impl<'a> OwnedEffect<'a> {
     pub(crate) fn clear_dependencies(&self, this: EffectRef) {
         let dependencies = &mut *self.dependencies.borrow_mut();
         for sig in dependencies.iter() {
-            sig.with(|sig| sig.unsubscribe(this));
+            sig.get().map(|sig| sig.unsubscribe(this));
         }
         dependencies.clear();
     }
@@ -53,7 +66,7 @@ impl<'a> OwnedEffect<'a> {
         // An effect is appended to the subscriber list of the signals since we
         // subscribe after running the closure.
         for sig in self.dependencies.borrow().iter() {
-            sig.with(|sig| sig.subscribe(self.this));
+            sig.get().map(|sig| sig.subscribe(self.this));
         }
 
         // 5) Restore previous observer.
@@ -84,8 +97,8 @@ where
 impl<'a> OwnedScope<'a> {
     fn create_effect_impl(&'a self, effect: &'a (dyn 'a + AnyEffect)) -> Effect<'a> {
         let shared = self.shared();
-        let owned = shared.effects.alloc_with_weak(|this| {
-            let owned = OwnedEffect {
+        let raw = shared.effects.alloc_with_weak(|this| {
+            let raw = RawEffect {
                 this,
                 effect,
                 shared,
@@ -93,12 +106,12 @@ impl<'a> OwnedScope<'a> {
             };
             // SAFETY: Same as `create_signal_context`, the effect cannot be
             // accessed once this scope is disposed.
-            unsafe { std::mem::transmute(owned) }
+            unsafe { std::mem::transmute(raw) }
         });
-        let effect = unsafe { owned.leak_ref() };
-        self.push_cleanup(Cleanup::Effect(owned));
-        effect.run();
-        effect
+        self.push_cleanup(Cleanup::Effect(raw));
+        let inner = raw.get().unwrap_or_else(|| unreachable!());
+        inner.run();
+        unsafe { self.create_variable_unchecked(OwnedEffect { inner }) }
     }
 
     /// Create an effect which accepts its previous returned value as the parameter
@@ -281,9 +294,10 @@ mod tests {
                     });
                 }
             });
-            let total = eff.dependencies.borrow().len();
+            let total = eff.inner.dependencies.borrow().len();
             assert_eq!(total, 1);
             let active = eff
+                .inner
                 .dependencies
                 .borrow()
                 .iter()

--- a/packages/reactive/src/effect.rs
+++ b/packages/reactive/src/effect.rs
@@ -82,7 +82,7 @@ where
 }
 
 impl<'a> OwnedScope<'a> {
-    fn create_effect_impl(&self, effect: &'a (dyn 'a + AnyEffect)) -> Effect<'a> {
+    fn create_effect_impl(&'a self, effect: &'a (dyn 'a + AnyEffect)) -> Effect<'a> {
         let shared = self.shared();
         let owned = shared.effects.alloc_with_weak(|this| {
             let owned = OwnedEffect {
@@ -137,7 +137,7 @@ mod tests {
     fn reactive_effect() {
         create_root(|cx| {
             let state = cx.create_signal(0);
-            let double = cx.create_variable(Cell::new(-1));
+            let double = cx.create_variable_static(Cell::new(-1));
 
             cx.create_effect(|_| {
                 double.set(*state.get() * 2);
@@ -242,8 +242,8 @@ mod tests {
     fn inner_effect_triggered_first() {
         create_root(|cx| {
             let state = cx.create_signal(());
-            let inner_counter = cx.create_variable(Cell::new(0));
-            let outer_counter = cx.create_variable(Cell::new(0));
+            let inner_counter = cx.create_variable_static(Cell::new(0));
+            let outer_counter = cx.create_variable_static(Cell::new(0));
 
             cx.create_effect(|_| {
                 state.track();

--- a/packages/reactive/src/lib.rs
+++ b/packages/reactive/src/lib.rs
@@ -6,8 +6,10 @@ mod scope;
 mod shared;
 mod signal;
 mod store;
+mod variable;
 
 pub use effect::{Effect, OwnedEffect};
 pub use scope::{create_root, BoundedOwnedScope, BoundedScope, OwnedScope, Scope, ScopeDisposer};
-pub use signal::{OwnedReadSignal, OwnedSignal, ReadSignal, Signal, SignalModify, SignalRef};
+pub use signal::{OwnedReadSignal, OwnedSignal, ReadSignal, Signal, SignalModify};
 pub use store::{CreateDefault, CreateSelf, CreateSignal, StoreBuilder};
+pub use variable::{OwnedVariable, VarRef, VarRefMut, Variable};

--- a/packages/reactive/src/shared.rs
+++ b/packages/reactive/src/shared.rs
@@ -1,6 +1,6 @@
 use crate::{
     arena::{Arena, WeakRef},
-    effect::OwnedEffect,
+    effect::RawEffect,
     scope::BoundedOwnedScope,
     signal::SignalContext,
 };
@@ -10,16 +10,16 @@ pub(crate) type InvariantLifetime<'a> = &'a mut &'a mut ();
 pub(crate) type CovariantLifetime<'a> = &'a ();
 
 pub(crate) type SignalContextRef = WeakRef<'static, SignalContext>;
-pub(crate) type EffectRef = WeakRef<'static, OwnedEffect<'static>>;
+pub(crate) type EffectRef = WeakRef<'static, RawEffect<'static>>;
 
 pub(crate) trait Empty {}
 impl<T> Empty for T {}
 
 #[derive(Default)]
 pub(crate) struct Shared {
-    pub observer: Cell<Option<WeakRef<'static, OwnedEffect<'static>>>>,
+    pub observer: Cell<Option<EffectRef>>,
     pub signal_contexts: Arena<SignalContext>,
-    pub effects: Arena<OwnedEffect<'static>>,
+    pub effects: Arena<RawEffect<'static>>,
     pub scopes: Arena<BoundedOwnedScope<'static, 'static>>,
 }
 

--- a/packages/reactive/src/signal.rs
+++ b/packages/reactive/src/signal.rs
@@ -11,7 +11,7 @@ use std::{cell::RefCell, fmt, ops::Deref};
 pub type Signal<'a, T> = &'a OwnedSignal<'a, T>;
 pub type ReadSignal<'a, T> = &'a OwnedReadSignal<'a, T>;
 
-pub struct OwnedReadSignal<'a, T: 'static> {
+pub struct OwnedReadSignal<'a, T> {
     value: RefCell<T>,
     context: &'a SignalContext,
 }
@@ -41,7 +41,7 @@ impl<'a, T> OwnedReadSignal<'a, T> {
     }
 }
 
-pub struct OwnedSignal<'a, T: 'static>(OwnedReadSignal<'a, T>);
+pub struct OwnedSignal<'a, T>(OwnedReadSignal<'a, T>);
 
 impl<'a, T> Deref for OwnedSignal<'a, T> {
     type Target = OwnedReadSignal<'a, T>;
@@ -204,6 +204,18 @@ mod tests {
             assert_eq!(*double.get(), 2);
             state.set_slient(2);
             assert_eq!(*double.get(), 2);
+        });
+    }
+
+    #[test]
+    fn signal_of_signal() {
+        create_root(|cx| {
+            let state = cx.create_signal(1);
+            let state2 = cx.create_signal(state);
+            let double = cx.create_memo(|| *state2.get().get() * 2);
+            assert_eq!(*state2.get().get(), 1);
+            state.set(2);
+            assert_eq!(*double.get(), 4);
         });
     }
 

--- a/packages/reactive/src/signal/modify.rs
+++ b/packages/reactive/src/signal/modify.rs
@@ -1,5 +1,6 @@
 use super::{OwnedSignal, SignalContext};
 use std::{
+    cell::RefMut,
     fmt,
     ops::{Deref, DerefMut},
 };
@@ -28,7 +29,7 @@ impl<'a, T> SignalModify<'a, T> {
     pub fn map<U>(this: Self, f: impl FnOnce(&mut T) -> &mut U) -> SignalModify<'a, U> {
         let SignalModify { value, trigger } = this;
         SignalModify {
-            value: std::cell::RefMut::map(value, f),
+            value: RefMut::map(value, f),
             trigger,
         }
     }

--- a/packages/reactive/src/variable.rs
+++ b/packages/reactive/src/variable.rs
@@ -1,0 +1,149 @@
+use crate::OwnedScope;
+use std::{
+    cell::{Ref, RefCell, RefMut},
+    marker::PhantomData,
+    ops::{Deref, DerefMut},
+};
+
+pub type Variable<'a, T> = &'a OwnedVariable<'a, T>;
+
+pub struct OwnedVariable<'a, T> {
+    disposed: bool,
+    value: RefCell<T>,
+    bounds: PhantomData<&'a ()>,
+}
+
+impl<T> Drop for OwnedVariable<'_, T> {
+    fn drop(&mut self) {
+        if self.value.try_borrow_mut().is_err() {
+            panic!("dispose a borrowed variable");
+        }
+        self.disposed = true;
+    }
+}
+
+impl<'a, T> OwnedVariable<'a, T> {
+    pub fn get(&self) -> VarRef<'_, T> {
+        self.try_get().expect("get a disposed varaible")
+    }
+
+    pub fn try_get(&self) -> Option<VarRef<'_, T>> {
+        if self.disposed {
+            return None;
+        }
+        Some(VarRef(self.value.borrow()))
+    }
+
+    pub fn get_mut(&self) -> VarRefMut<'_, T> {
+        self.try_get_mut().expect("get a disposed variable")
+    }
+
+    pub fn try_get_mut(&self) -> Option<VarRefMut<'_, T>> {
+        if self.disposed {
+            return None;
+        }
+        Some(VarRefMut(self.value.borrow_mut()))
+    }
+}
+
+pub struct VarRef<'a, T>(Ref<'a, T>);
+
+impl<'a, T> From<&'a RefCell<T>> for VarRef<'a, T> {
+    fn from(r: &'a RefCell<T>) -> Self {
+        VarRef(r.borrow())
+    }
+}
+
+impl<'a, T> VarRef<'a, T> {
+    pub fn map<U>(orig: Self, f: impl FnOnce(&T) -> &U) -> VarRef<'a, U> {
+        VarRef(Ref::map(orig.0, f))
+    }
+}
+
+impl<T> Deref for VarRef<'_, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+pub struct VarRefMut<'a, T>(RefMut<'a, T>);
+
+impl<'a, T> From<&'a RefCell<T>> for VarRefMut<'a, T> {
+    fn from(r: &'a RefCell<T>) -> Self {
+        VarRefMut(r.borrow_mut())
+    }
+}
+
+impl<T> Deref for VarRefMut<'_, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> DerefMut for VarRefMut<'_, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<'a, T> VarRefMut<'a, T> {
+    pub fn map<U>(orig: Self, f: impl FnOnce(&mut T) -> &mut U) -> VarRefMut<'a, U> {
+        VarRefMut(RefMut::map(orig.0, f))
+    }
+}
+
+impl<'a> OwnedScope<'a> {
+    pub fn create_owned_variable<T>(&'a self, t: T) -> OwnedVariable<'a, T> {
+        OwnedVariable {
+            disposed: false,
+            value: RefCell::new(t),
+            bounds: PhantomData,
+        }
+    }
+
+    pub fn create_variable<T>(&'a self, t: T) -> Variable<'a, T> {
+        let owned = self.create_owned_variable(t);
+        unsafe { self.create_variable_unchecked(owned) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::create_root;
+    use std::cell::Cell;
+
+    #[test]
+    fn cannot_read_disposed_variable() {
+        struct DropAndRead<'a> {
+            ref_to: Cell<Option<Variable<'a, String>>>,
+        }
+        impl Drop for DropAndRead<'_> {
+            fn drop(&mut self) {
+                assert!(self.ref_to.get().unwrap().try_get().is_none());
+            }
+        }
+
+        create_root(|cx| {
+            let var1 = cx.create_variable(DropAndRead {
+                ref_to: Default::default(),
+            });
+            let var2 = cx.create_variable(String::from("Hello, xFrame!"));
+            var1.get().ref_to.set(Some(var2));
+        });
+    }
+
+    #[test]
+    #[should_panic = "dispose a borrowed variable"]
+    fn cannot_dispose_borrowed_varialbe() {
+        create_root(|cx| {
+            let var = cx.create_variable(None);
+            let var2 = cx.create_variable(0);
+            *var.get_mut() = Some(var2.get());
+        });
+    }
+}


### PR DESCRIPTION
Another try to fix #1. Wrapping variables with a flag which indicates whether it has been disposed, this is a more general approach than simply introducing a `'static` restriction.