### PR TITLE
refactor(reactive): use a thread local `Shared` object

### DIFF
--- a/packages/reactive/src/lib.rs
+++ b/packages/reactive/src/lib.rs
@@ -7,8 +7,8 @@ mod signal;
 mod store;
 mod variable;
 
-type InvariantLifetime<'a> = &'a mut &'a mut ();
-type CovariantLifetime<'a> = &'a mut ();
+type InvariantLifetime<'a> = *mut &'a ();
+type CovariantLifetime<'a> = *const &'a ();
 
 trait Empty {}
 impl<T> Empty for T {}

--- a/packages/reactive/src/lib.rs
+++ b/packages/reactive/src/lib.rs
@@ -1,3 +1,5 @@
+#![warn(clippy::undocumented_unsafe_blocks)]
+
 mod context;
 mod effect;
 mod memo;

--- a/packages/reactive/src/shared.rs
+++ b/packages/reactive/src/shared.rs
@@ -11,6 +11,10 @@ use std::{
     ptr::NonNull,
 };
 
+thread_local! {
+    pub(crate) static SHARED: Shared = <_>::default();
+}
+
 new_key_type! {
     pub(crate) struct ScopeId;
     pub(crate) struct SignalId;

--- a/packages/reactive/src/variable.rs
+++ b/packages/reactive/src/variable.rs
@@ -163,7 +163,7 @@ mod tests {
         create_root(|cx| {
             let var1 = cx.create_variable(DropAndRead(None));
             let var2 = cx.create_variable(0);
-            (&mut *var1.get_mut()).0 = Some(var2);
+            (*var1.get_mut()).0 = Some(var2);
         });
     }
 

--- a/packages/reactive/src/variable.rs
+++ b/packages/reactive/src/variable.rs
@@ -1,7 +1,7 @@
 use crate::{
     scope::{Cleanup, RawScope, Scope},
-    shared::{Shared, VariableId},
-    Empty,
+    shared::{Shared, VariableId, SHARED},
+    CovariantLifetime, Empty,
 };
 use std::{
     cell::{Ref, RefCell, RefMut},
@@ -12,8 +12,7 @@ use std::{
 
 pub struct Variable<'a, T> {
     pub(crate) id: VariableId,
-    pub(crate) shared: &'a Shared,
-    ty: PhantomData<T>,
+    marker: PhantomData<(T, CovariantLifetime<'a>)>,
 }
 
 impl<T> Clone for Variable<'_, T> {
@@ -26,16 +25,17 @@ impl<T> Copy for Variable<'_, T> {}
 
 impl<'a, T> Variable<'a, T> {
     fn value(&self) -> &'a VarSlot<T> {
-        let ptr = self
-            .shared
-            .variables
-            .borrow()
-            .get(self.id)
-            .copied()
-            .unwrap_or_else(|| panic!("tried to access a disposed variable"));
-        // SAFETY: The type is assumed by the marker `ty` and the allocated variable
-        // lives as long as current `Scope`.
-        unsafe { ptr.cast().as_ref() }
+        SHARED.with(|shared| {
+            let ptr = shared
+                .variables
+                .borrow()
+                .get(self.id)
+                .copied()
+                .unwrap_or_else(|| panic!("tried to access a disposed variable"));
+            // SAFETY: The type is assumed by the marker `ty` and the allocated variable
+            // lives as long as current `Scope`.
+            unsafe { ptr.cast().as_ref() }
+        })
     }
 
     pub fn get(&self) -> VarRef<'_, T> {
@@ -112,11 +112,10 @@ impl<T> DerefMut for VarRefMut<'_, T> {
 }
 
 impl VariableId {
-    pub(crate) unsafe fn create_variable<'a, T>(&self, shared: &'a Shared) -> Variable<'a, T> {
+    pub(crate) unsafe fn create_variable<'a, T>(&self) -> Variable<'a, T> {
         Variable {
             id: *self,
-            shared,
-            ty: PhantomData,
+            marker: PhantomData,
         }
     }
 }
@@ -135,16 +134,14 @@ impl RawScope {
         self.add_cleanup(Cleanup::Variable(id));
         Variable {
             id,
-            shared,
-            ty: PhantomData,
+            marker: PhantomData,
         }
     }
 }
 
 impl<'a> Scope<'a> {
     pub fn create_variable<T: 'a>(&self, t: T) -> Variable<'a, T> {
-        self.id
-            .with(self.shared, |cx| cx.create_variable(self.shared, t))
+        self.with_shared(|shared| self.id.with(shared, |cx| cx.create_variable(shared, t)))
     }
 }
 


### PR DESCRIPTION
Uses a thread-local `Shared` variable rather than `Box` allocation for each root scope, this can speed up the destruction of root scopes and reuse allocated slots. In addition, as mentioned in #6, a static variable can also improve the safety of resource management.